### PR TITLE
Emergency hotfix

### DIFF
--- a/includes/executor.h
+++ b/includes/executor.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/08/01 02:23:28 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/08/03 19:18:26 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,7 +80,7 @@ void    	cmd_lst_addback(t_commands **cmds, t_commands *new);
 
 /*====================================EXECUTOR================================*/
 
-void		parameter_expansion(char **args);
+void		shell_expansion(char **args);
 t_process	init_process(t_commands *cmds, char **envp, int pipe_read_end_prev);
 void		child_process(t_process *process);
 pid_t 		create_process(t_process *process);

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 11:46:39 by wlin              #+#    #+#             */
-/*   Updated: 2024/08/01 11:09:54 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/08/03 20:32:20 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,7 +81,7 @@ void	execute_all(t_commands *cmds, char **envp)
 	pipe_read_end_prev = dup(STDIN_FILENO);
 	while (cmds)
 	{
-		parameter_expansion(cmds->args);
+		shell_expansion(cmds->args);
 		process = init_process(cmds, envp, pipe_read_end_prev);
 		if (process.command != NULL)
 		{

--- a/src/executor/process_init.c
+++ b/src/executor/process_init.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/27 18:46:09 by wlin              #+#    #+#             */
-/*   Updated: 2024/08/02 13:02:29 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/08/03 19:12:20 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,50 +72,4 @@ t_process	init_process(t_commands *cmds, char **envp, int pipe_read_end_prev)
 		tmp_redirect = tmp_redirect->next;
 	}
 	return (process);
-}
-
-static void	construct_new_arg(char **args, char **const arg)
-{
-	char *const	empty = "";
-	char		*arg_param;
-	char		*str1;
-	char		*str2;
-	int			ok_first;
-
-	*(*arg)++ = '\0';
-	arg_param = *arg;
-	ok_first = (ft_isalpha(**arg) || **arg == UNDERSCORE);
-	++*arg;
-	while (ok_first && (ft_isalnum(**arg) || **arg == UNDERSCORE))
-		++*arg;
-	str1 = ft_substr(arg_param, 0, *arg - arg_param);
-	arg_param = getenv(str1);
-	if (!arg_param)
-		arg_param = empty;
-	str2 = ft_strjoin(*args, arg_param);
-	free(str1);
-	str1 = ft_strjoin(str2, *arg);
-	*arg = str1 + ft_strlen(str2) - 1;
-	free(str2);
-	free(*args);
-	*args = str1;
-}
-
-void	parameter_expansion(char **args)
-{
-	char	*arg;
-
-	while (*args)
-	{
-		arg = *args;
-		while (*arg)
-		{
-			if (*arg == QUOTE_S)
-				arg = ft_strchr(++arg, QUOTE_S);
-			else if (*arg == DOLLAR)
-				construct_new_arg(args, &arg);
-			++arg;
-		}
-		++args;
-	}
 }

--- a/src/executor/process_init.c
+++ b/src/executor/process_init.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/27 18:46:09 by wlin              #+#    #+#             */
-/*   Updated: 2024/08/01 11:38:28 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/08/02 13:02:29 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,20 +74,25 @@ t_process	init_process(t_commands *cmds, char **envp, int pipe_read_end_prev)
 	return (process);
 }
 
-static void	construct_new_arg(char **args, char **arg)
+static void	construct_new_arg(char **args, char **const arg)
 {
-	char *const	arg0 = *arg + 1;
+	char *const	empty = "";
+	char		*arg_param;
 	char		*str1;
 	char		*str2;
 	int			ok_first;
 
 	*(*arg)++ = '\0';
+	arg_param = *arg;
 	ok_first = (ft_isalpha(**arg) || **arg == UNDERSCORE);
 	++*arg;
 	while (ok_first && (ft_isalnum(**arg) || **arg == UNDERSCORE))
 		++*arg;
-	str1 = ft_substr(arg0, 0, *arg - arg0);
-	str2 = ft_strjoin(*args, getenv(str1));
+	str1 = ft_substr(arg_param, 0, *arg - arg_param);
+	arg_param = getenv(str1);
+	if (!arg_param)
+		arg_param = empty;
+	str2 = ft_strjoin(*args, arg_param);
 	free(str1);
 	str1 = ft_strjoin(str2, *arg);
 	*arg = str1 + ft_strlen(str2) - 1;

--- a/src/executor/shell_expansion.c
+++ b/src/executor/shell_expansion.c
@@ -1,0 +1,83 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   shell_expansion.c                                  :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/08/03 19:12:32 by rtorrent          #+#    #+#             */
+/*   Updated: 2024/08/03 20:24:07 by rtorrent         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+#include "executor.h"
+#include "macros.h"
+
+static void	quote_removal(char **const args, char **const parg, const char q)
+{
+	char	*arg_close;
+	char	*str1;
+	char	*str2;
+
+	*(*parg)++ = '\0';
+	arg_close = ft_strchr(*parg, q);
+	str1 = ft_substr(*parg, 0, arg_close - *parg);
+	str2 = ft_strjoin(*args, str1);
+	free(str1);
+	str1 = ft_strjoin(str2, ++arg_close);
+	if (q == QUOTE_S)
+		*parg = str1 + ft_strlen(str2);
+	else
+		*parg = str1 + ft_strlen(*args);
+	free(str2);
+	free(*args);
+	*args = str1;
+}
+
+static void	parameter_expansion(char **const args, char **const parg)
+{
+	char *const	empty = "";
+	char		*arg_param;
+	char		*str1;
+	char		*str2;
+	int			ok_first;
+
+	*(*parg)++ = '\0';
+	arg_param = *parg;
+	ok_first = (ft_isalpha(**parg) || **parg == UNDERSCORE);
+	++*parg;
+	while (ok_first && (ft_isalnum(**parg) || **parg == UNDERSCORE))
+		++*parg;
+	str1 = ft_substr(arg_param, 0, *parg - arg_param);
+	arg_param = getenv(str1);
+	if (!arg_param)
+		arg_param = empty;
+	str2 = ft_strjoin(*args, arg_param);
+	free(str1);
+	str1 = ft_strjoin(str2, *parg);
+	*parg = str1 + ft_strlen(str2);
+	free(str2);
+	free(*args);
+	*args = str1;
+}
+
+void	shell_expansion(char **args)
+{
+	char	*arg;
+
+	while (*args)
+	{
+		arg = *args;
+		while (*arg)
+		{
+			if (*arg == QUOTE_S || *arg == QUOTE_D)
+				quote_removal(args, &arg, *arg);
+			else if (*arg == DOLLAR)
+				parameter_expansion(args, &arg);
+			else
+				++arg;
+		}
+		++args;
+	}
+}


### PR DESCRIPTION
Repaired the segmentation fault resulting from environment variables not found. Also changed a variable name you did not approve of: `arg0` to `arg_param`.

BTW, `$?` is already implemented in the _expansor_. If no result is displayed with such commands as `echo $?`, it is because our shell does not (yet) manage its own environment. **minishell**'s exit code return is still a work-in-progress, and this code should be stored in the `?` variable.

Incorporated **quote removal** with the second commit.