### PR TITLE
Fix to single quotes inside double quotes

### DIFF
--- a/includes/macros.h
+++ b/includes/macros.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/01 17:38:17 by wlin              #+#    #+#             */
-/*   Updated: 2024/08/01 02:12:44 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/08/11 20:40:13 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,7 @@
 # define QUOTE_S 39
 # define QUOTE_D 34
 # define DOLLAR 36
+# define QUESTION 63
 # define UNDERSCORE 95
 # define C_PIPE 124
 # define C_LESS 60

--- a/src/executor/shell_expansion.c
+++ b/src/executor/shell_expansion.c
@@ -6,13 +6,44 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 19:12:32 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/08/03 20:24:07 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/08/11 20:43:30 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 #include "executor.h"
 #include "macros.h"
+
+static int	is_paramter(char *arg)
+{
+	return (*arg++ == DOLLAR && (*arg == QUESTION
+			|| ft_isalpha(*arg) || *arg == UNDERSCORE));
+}
+
+static void	parameter_expansion(char **const args, char **const parg)
+{
+	char *const	empty = "";
+	char		*arg_param;
+	char		*str1;
+	char		*str2;
+
+	*(*parg)++ = '\0';
+	arg_param = (*parg)++;
+	if (*arg_param != QUESTION)
+		while (ft_isalnum(**parg) || **parg == UNDERSCORE)
+			++*parg;
+	str1 = ft_substr(arg_param, 0, *parg - arg_param);
+	arg_param = getenv(str1);
+	if (!arg_param)
+		arg_param = empty;
+	str2 = ft_strjoin(*args, arg_param);
+	free(str1);
+	str1 = ft_strjoin(str2, *parg);
+	*parg = str1 + ft_strlen(str2);
+	free(str2);
+	free(*args);
+	*args = str1;
+}
 
 static void	quote_removal(char **const args, char **const parg, const char q)
 {
@@ -23,39 +54,20 @@ static void	quote_removal(char **const args, char **const parg, const char q)
 	*(*parg)++ = '\0';
 	arg_close = ft_strchr(*parg, q);
 	str1 = ft_substr(*parg, 0, arg_close - *parg);
+	if (q == QUOTE_D)
+	{
+		str2 = str1;
+		while (*str2)
+		{
+			if (is_paramter(str2))
+				parameter_expansion(&str1, &str2);
+			else
+				++str2;
+		}
+	}
 	str2 = ft_strjoin(*args, str1);
 	free(str1);
 	str1 = ft_strjoin(str2, ++arg_close);
-	if (q == QUOTE_S)
-		*parg = str1 + ft_strlen(str2);
-	else
-		*parg = str1 + ft_strlen(*args);
-	free(str2);
-	free(*args);
-	*args = str1;
-}
-
-static void	parameter_expansion(char **const args, char **const parg)
-{
-	char *const	empty = "";
-	char		*arg_param;
-	char		*str1;
-	char		*str2;
-	int			ok_first;
-
-	*(*parg)++ = '\0';
-	arg_param = *parg;
-	ok_first = (ft_isalpha(**parg) || **parg == UNDERSCORE);
-	++*parg;
-	while (ok_first && (ft_isalnum(**parg) || **parg == UNDERSCORE))
-		++*parg;
-	str1 = ft_substr(arg_param, 0, *parg - arg_param);
-	arg_param = getenv(str1);
-	if (!arg_param)
-		arg_param = empty;
-	str2 = ft_strjoin(*args, arg_param);
-	free(str1);
-	str1 = ft_strjoin(str2, *parg);
 	*parg = str1 + ft_strlen(str2);
 	free(str2);
 	free(*args);
@@ -73,7 +85,7 @@ void	shell_expansion(char **args)
 		{
 			if (*arg == QUOTE_S || *arg == QUOTE_D)
 				quote_removal(args, &arg, *arg);
-			else if (*arg == DOLLAR)
+			else if (is_paramter(arg))
 				parameter_expansion(args, &arg);
 			else
 				++arg;


### PR DESCRIPTION
Quotes inside quotes work now as intended. Identifiers and '?' are expanded correctly from the local environment. (Variable '?', storing the last exit code, is still in the future.)