### PR TITLE
Memory allocation protection in 'shell_expansion.c'

### DIFF
--- a/src/executor/shell_expansion.c
+++ b/src/executor/shell_expansion.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 19:12:32 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/08/21 15:22:22 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/08/22 14:58:00 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,10 +20,9 @@ static int	is_parameter(char *arg)
 
 static void	parameter_expansion(char **args, char **parg, t_data *data)
 {
-	char *const	empty = "";
-	char		*arg_param;
-	char		*str1;
-	char		*str2;
+	char	*arg_param;
+	char	*str1;
+	char	*str2;
 
 	*(*parg)++ = '\0';
 	arg_param = (*parg)++;
@@ -34,14 +33,15 @@ static void	parameter_expansion(char **args, char **parg, t_data *data)
 		str1 = ft_substr(arg_param, 0, *parg - arg_param);
 		arg_param = getenv(str1);
 		if (!arg_param)
-			arg_param = empty;
+			arg_param = "";
 		free(str1);
 	}
 	else
 		arg_param = data->exit_status;
 	str2 = ft_strjoin(*args, arg_param);
 	str1 = ft_strjoin(str2, *parg);
-	*parg = str1 + ft_strlen(str2);
+	if (str1 && str2)
+		*parg = str1 + ft_strlen(str2);
 	free(str2);
 	free(*args);
 	*args = str1;
@@ -56,21 +56,19 @@ static void	quote_removal(char **args, char **parg, const char q, t_data *data)
 	*(*parg)++ = '\0';
 	arg_close = ft_strchr(*parg, q);
 	str1 = ft_substr(*parg, 0, arg_close - *parg);
-	if (q == QUOTE_D)
+	str2 = str1;
+	while (q == QUOTE_D && str1 && str2 && *str2)
 	{
-		str2 = str1;
-		while (*str2)
-		{
-			if (is_parameter(str2))
-				parameter_expansion(&str1, &str2, data);
-			else
-				++str2;
-		}
+		if (is_parameter(str2))
+			parameter_expansion(&str1, &str2, data);
+		else
+			++str2;
 	}
 	str2 = ft_strjoin(*args, str1);
 	free(str1);
 	str1 = ft_strjoin(str2, ++arg_close);
-	*parg = str1 + ft_strlen(str2);
+	if (str1 && str2)
+		*parg = str1 + ft_strlen(str2);
 	free(str2);
 	free(*args);
 	*args = str1;
@@ -85,7 +83,7 @@ void	shell_expansion(char **args, t_data *data)
 	while (*args)
 	{
 		arg = *args;
-		while (*arg)
+		while (arg && *arg)
 		{
 			if (*arg == QUOTE_S || *arg == QUOTE_D)
 				quote_removal(args, &arg, *arg, data);


### PR DESCRIPTION
Placed checkpoints in the shell expansion to protect from failed memory allocation in the string functions.