### PR TITLE
Exit status code & 'exit' builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/30 13:11:23 by wlin              #+#    #+#              #
-#    Updated: 2024/09/04 11:04:33 by rtorrent         ###   ########.fr        #
+#    Updated: 2024/09/07 19:10:10 by rtorrent         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -14,7 +14,7 @@ AUTHORS			= wlin rtorrent
 NAME			= minishell
 
 CC				= gcc
-CFLAGS			= -Wall -Wextra -Werror -g -Iincludes -I${LIBFT_DIR} -fsanitize=address -MMD
+CFLAGS			= -Wall -Wextra -Werror -g -Iincludes -I${LIBFT_DIR} -MMD
 RM				= rm -fr
 
 #<--------------------------------->FILES<------------------------------------>#
@@ -87,10 +87,10 @@ header:
 	@echo " | |  | | | | | | \__ \ | | |  __/ | |"
 	@echo " |_|  |_|_|_| |_|_|___/_| |_|\___|_|_|"
 	@echo
-	@printf "%b" "$(BLUE)Name:	$(RED)$(NAME)\n"
-	@printf "%b" "$(BLUE)Authors:	$(RED)$(AUTHORS)\n"
-	@printf "%b" "$(BLUE)CC: 	$(RED)$(CC)\n\033[m"
-	@printf "%b" "$(BLUE)Flags: 	$(RED)$(CFLAGS)\n\033[m"
+	@printf "%b" "$(BLUE)Name:	  $(RED)$(NAME)\n"
+	@printf "%b" "$(BLUE)Authors:  $(RED)$(AUTHORS)\n"
+	@printf "%b" "$(BLUE)CC: 	  $(RED)$(CC)\n"
+	@printf "%b" "$(BLUE)Flags:   $(RED)$(CFLAGS)$(RESET)\n"
 	@echo
 
 libft:

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/30 13:11:23 by wlin              #+#    #+#              #
-#    Updated: 2024/09/07 19:10:10 by rtorrent         ###   ########.fr        #
+#    Updated: 2024/09/08 02:01:22 by rtorrent         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -87,9 +87,9 @@ header:
 	@echo " | |  | | | | | | \__ \ | | |  __/ | |"
 	@echo " |_|  |_|_|_| |_|_|___/_| |_|\___|_|_|"
 	@echo
-	@printf "%b" "$(BLUE)Name:	  $(RED)$(NAME)\n"
-	@printf "%b" "$(BLUE)Authors:  $(RED)$(AUTHORS)\n"
-	@printf "%b" "$(BLUE)CC: 	  $(RED)$(CC)\n"
+	@printf "%b" "$(BLUE)Name:    $(RED)$(NAME)\n"
+	@printf "%b" "$(BLUE)Authors: $(RED)$(AUTHORS)\n"
+	@printf "%b" "$(BLUE)CC:      $(RED)$(CC)\n"
 	@printf "%b" "$(BLUE)Flags:   $(RED)$(CFLAGS)$(RESET)\n"
 	@echo
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/30 13:11:23 by wlin              #+#    #+#              #
-#    Updated: 2024/09/08 02:01:22 by rtorrent         ###   ########.fr        #
+#    Updated: 2024/09/08 17:36:00 by rtorrent         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -31,7 +31,7 @@ FILES_LEXR		= lexer.c utils_list.c utils_str.c
 FILES_PARS		= parser.c parser_syntax.c parser_utils.c
 FILES_EXEC		= executor.c exec_find_cmd.c here_doc.c process_init.c\
 				  process.c exec_utils.c  split_path.c shell_expansion.c
-FILES_BLT		= builtin.c env.c pwd.c unset.c
+FILES_BLT		= builtin.c env.c exit.c pwd.c unset.c
 FILES_AUX		= aux_array.c aux_str.c
 FILES_TEST		= test_lexer.c
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/07 18:53:22 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/07 20:04:03 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,15 +42,16 @@
 # define INVALID -1
 # define NONE 0
 
-# define QUOTE_S 39
 # define QUOTE_D 34
 # define DOLLAR 36
+# define QUOTE_S 39
 # define C_LESS 60
 # define EQUALS 61
 # define C_GREAT 62
 # define QUESTION 63
 # define UNDERSCORE 95
 # define C_PIPE 124
+# define TILDE 126
 
 # define NEGATIVE 0
 # define CHILD 0
@@ -95,8 +96,8 @@ typedef struct s_token
 
 typedef struct s_data
 {
+	int			exit_status;
 	char		**envp;
-	char		*exit_status;
 	char		*line;
 	t_token		*tokens;
 	t_commands	*cmds;

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/08 02:29:59 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 14:27:17 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -106,7 +106,7 @@ typedef struct s_data
 	pid_t		*pid;
 }	t_data;
 
-typedef int	(*t_bfunc)(int argc, char *argv[]);
+typedef int	(*t_bfunc)(int argc, char *argv[], t_data *data);
 
 typedef struct s_process
 {
@@ -128,7 +128,8 @@ typedef struct s_str
 
 /*===================================MINISHELL================================*/
 
-void		exit_minishell(t_data *data, char *str, char *error_str, int code);
+int			error_message(char *source, char *err_str, int code);
+void		exit_minishell(t_data *data, char *source, char *err_str, int code);
 
 /*======================================LEXER=================================*/
 
@@ -173,12 +174,12 @@ int			read_here_doc(char *limiter);
 
 /*======================================BUILTIN===============================*/
 
-int			bt_cd(int argc, char *argv[]);
-int			bt_env(int argc, char *argv[]);
-int			bt_exit(int argc, char *argv[]);
-int			bt_export(int argc, char *argv[]);
-int			bt_pwd(int argc, char *argv[]);
-int			bt_unset(int argc, char *argv[]);
+int			bt_cd(int argc, char *argv[], t_data *data);
+int			bt_env(int argc, char *argv[], t_data *data);
+int			bt_exit(int argc, char *argv[], t_data *data);
+int			bt_export(int argc, char *argv[], t_data *data);
+int			bt_pwd(int argc, char *argv[], t_data *data);
+int			bt_unset(int argc, char *argv[], t_data *data);
 int			is_builtin(t_bfunc *dst, char *cmd);
 
 /*===============================AUXILIARY FUNCTIONS==========================*/

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,12 +6,14 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/04 10:50:53 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/07 18:53:22 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef MINISHELL_H
 # define MINISHELL_H
+
+# define _GNU_SOURCE
 
 # include <errno.h>
 # include <fcntl.h>
@@ -93,6 +95,7 @@ typedef struct s_token
 
 typedef struct s_data
 {
+	char		**envp;
 	char		*exit_status;
 	char		*line;
 	t_token		*tokens;

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/07 20:04:03 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 02:29:59 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,6 +60,7 @@
 
 # define NOTEXECUTABLE 126
 # define NOTFOUND 127
+# define FATALSIGNAL 128
 
 typedef enum e_metachar
 {

--- a/src/auxiliaries/aux_array.c
+++ b/src/auxiliaries/aux_array.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <rtorrent@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/28 21:08:04 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/08/29 03:12:04 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/06 19:45:45 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,7 @@ void	array_clear(char ***parray)
 	char	**a;
 
 	a = *parray;
-	if (!*a)
+	if (!a)
 		return ;
 	while (*a)
 		free(*a++);
@@ -46,12 +46,11 @@ char	**array_dup(char **array)
 		while (*array)
 		{
 			*a = ft_strdup(*array++);
-			if (!*a)
+			if (!*a++)
 			{
 				array_clear(&a0);
 				break ;
 			}
-			a++;
 		}
 		*a = NULL;
 	}

--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/21 14:12:00 by wlin              #+#    #+#             */
-/*   Updated: 2024/08/28 12:34:29 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 17:33:52 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,9 @@
 
 int	is_builtin(t_bfunc *dst, char *cmd)
 {
-	static const char		*builtin[] = {"env", "pwd", "unset", NULL};
-	static const t_bfunc	bt_func[] = {bt_env, bt_pwd, bt_unset, NULL};
+	static const char		*builtin[] = {"env", "exit", "pwd", "unset", NULL};
+	static const t_bfunc	bt_func[] = {bt_env, bt_exit, bt_pwd, bt_unset,
+		NULL};
 	const char				**b;
 
 	b = builtin;

--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/23 12:41:57 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/08/26 15:04:01 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/07 18:50:46 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,8 +14,7 @@
 
 int	bt_env(int argc, char *argv[])
 {
-	extern char	**environ;
-	char		**ep;
+	char	**ep;
 
 	(void)argc;
 	(void)argv;

--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -6,22 +6,25 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/23 12:41:57 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/09/07 18:50:46 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 14:57:14 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	bt_env(int argc, char *argv[])
+#define ENV_ERROR 125
+
+int	bt_env(int argc, char *argv[], t_data *data)
 {
 	char	**ep;
 
-	(void)argc;
 	(void)argv;
+	(void)data;
 	ep = environ;
-	if (!ep)
-		return (1);
-	while (*ep)
-		printf("%s\n", *ep++);
-	return (0);
+	if (argc > 1)
+		return (error_message("env", "invalid option/argument", ENV_ERROR));
+	if (ep)
+		while (*ep)
+			printf("%s\n", *ep++);
+	return (EXIT_SUCCESS);
 }

--- a/src/builtin/exit.c
+++ b/src/builtin/exit.c
@@ -1,0 +1,60 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   exit.c                                             :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: rtorrent <rtorrent@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/09/08 17:36:35 by rtorrent          #+#    #+#             */
+/*   Updated: 2024/09/08 20:04:47 by rtorrent         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+#define EXIT_ERROR 2
+#define BUFFER_ERROR 128
+
+static int	atoi_version(int *err, char *str)
+{
+	int	n;
+	int	sign;
+
+	while (is_whitespace(*str))
+		str++;
+	sign = *str == '-';
+	if (*str == '-' || *str == '+')
+		str++;
+	n = 0;
+	while (ft_isdigit(*str))
+	{
+		n *= 10;
+		if (sign)
+			n -= *str++ - '0';
+		else
+			n += *str++ - '0';
+	}
+	*err = *str;
+	return (n);
+}
+
+int	bt_exit(int argc, char *argv[], t_data *data)
+{
+	int		n;
+	int		err;
+	char	non_numeric[BUFFER_ERROR];
+
+	ft_putendl_fd("exit", STDOUT_FILENO);
+	if (argc == 1)
+		exit_minishell(data, NULL, NULL, data->exit_status);
+	if (argc > 2)
+		return (error_message("minishell: exit", "too many arguments",
+				EXIT_ERROR));
+	ft_strlcpy(non_numeric, *++argv, BUFFER_ERROR);
+	ft_strlcat(non_numeric, ": numeric argument required", BUFFER_ERROR);
+	n = atoi_version(&err, *argv);
+	if (err)
+		exit_minishell(data, "exit", non_numeric, EXIT_ERROR);
+	exit_minishell(data, NULL, NULL, n & 0377);
+	return (EXIT_SUCCESS);
+}

--- a/src/builtin/pwd.c
+++ b/src/builtin/pwd.c
@@ -6,23 +6,27 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 14:06:28 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/08/27 14:53:48 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 15:05:24 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-int	bt_pwd(int argc, char *argv[])
+#define PWD_ERROR 2
+
+int	bt_pwd(int argc, char *argv[], t_data *data)
 {
 	char	buffer[PATH_MAX];
 	char	*pwd;
 
-	(void)argc;
 	(void)argv;
+	(void)data;
+	if (argc > 1)
+		return (error_message("pwd", "invalid option", PWD_ERROR));
 	if (getcwd(buffer, PATH_MAX))
 		pwd = buffer;
 	else
 		pwd = getenv("PWD");
 	printf("%s\n", pwd);
-	return (0);
+	return (EXIT_SUCCESS);
 }

--- a/src/builtin/unset.c
+++ b/src/builtin/unset.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/28 12:06:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/08/29 12:31:33 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/07 18:51:20 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,10 +27,9 @@ static void	remove_name(char **ep)
 
 int	bt_unset(int argc, char *argv[])
 {
-	extern char	**environ;
-	char		**ep;
-	size_t		n;
-	int			ret;
+	char	**ep;
+	size_t	n;
+	int		ret;
 
 	if (!environ)
 		return (-1);

--- a/src/builtin/unset.c
+++ b/src/builtin/unset.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/28 12:06:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/09/07 18:51:20 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 15:24:53 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,12 +25,13 @@ static void	remove_name(char **ep)
 	}
 }
 
-int	bt_unset(int argc, char *argv[])
+int	bt_unset(int argc, char *argv[], t_data *data)
 {
 	char	**ep;
 	size_t	n;
 	int		ret;
 
+	(void)data;
 	if (!environ)
 		return (-1);
 	ret = 0;

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 11:46:39 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/08 02:42:52 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 14:02:26 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ void	simple_command(t_data *data, t_process *process, int pipe_read_end_prev)
 		close(process->fd_in);
 		close(process->fd_out);
 		data->exit_status = (*process->builtin)(array_len(process->command),
-				process->command);
+				process->command, data) & 0xff;
 		fd_dup2(data, fd_storage[RD], STDIN_FILENO);
 		fd_dup2(data, fd_storage[WR], STDOUT_FILENO);
 		close(fd_storage[RD]);

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 11:46:39 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/04 10:59:08 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/07 18:52:08 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,8 +63,7 @@ void	wait_process(pid_t *pid_array, int num_cmd)
 
 void	execute_command(t_data *data, char *command_path, char **cmd_args)
 {
-	extern char	**environ;
-	char		*shell_path;
+	char	*shell_path;
 
 	execve(command_path, cmd_args, environ);
 	if (errno == ENOEXEC)

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 11:46:39 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/08 14:02:26 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 17:39:41 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,7 +27,7 @@ void	simple_command(t_data *data, t_process *process, int pipe_read_end_prev)
 		close(process->fd_in);
 		close(process->fd_out);
 		data->exit_status = (*process->builtin)(array_len(process->command),
-				process->command, data) & 0xff;
+				process->command, data) & 0377;
 		fd_dup2(data, fd_storage[RD], STDIN_FILENO);
 		fd_dup2(data, fd_storage[WR], STDOUT_FILENO);
 		close(fd_storage[RD]);

--- a/src/executor/process.c
+++ b/src/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/23 18:16:01 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/03 20:33:47 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 13:57:44 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ void	child_process(t_data *data, t_process *process)
 	if (access(cmd_path, F_OK) == 0 && access(cmd_path, X_OK) == -1)
 		exit_minishell(data, command[0], "Permission denied", NOTEXECUTABLE);
 	if (process->builtin)
-		exit((*process->builtin)(array_len(command), command));
+		exit((*process->builtin)(array_len(command), command, data));
 	execute_command(data, cmd_path, command);
 }
 

--- a/src/executor/shell_expansion.c
+++ b/src/executor/shell_expansion.c
@@ -6,45 +6,67 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 19:12:32 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/09/02 14:52:48 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/07 21:02:17 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static int	is_parameter(char *arg)
-{
-	return (*arg++ == DOLLAR && (*arg == QUESTION
-			|| ft_isalpha(*arg) || *arg == UNDERSCORE));
-}
-
-static void	parameter_expansion(char **args, char **parg, t_data *data)
+static void	parameter_expansion(char **args, char **parg, t_data *data, int t)
 {
 	char	*arg_param;
 	char	*str1;
 	char	*str2;
 
-	*(*parg)++ = '\0';
-	arg_param = (*parg)++;
-	if (*arg_param != QUESTION)
+	if (t == TILDE)
+	{
+		str1 = NULL;
+		arg_param = getenv("HOME");
+	}
+	else
+		arg_param = (*parg)++;
+	if (t == DOLLAR)
 	{
 		while (ft_isalnum(**parg) || **parg == UNDERSCORE)
 			++*parg;
 		str1 = ft_substr(arg_param, 0, *parg - arg_param);
 		arg_param = getenv(str1);
-		if (!arg_param)
-			arg_param = "";
-		free(str1);
 	}
-	else
-		arg_param = data->exit_status;
+	else if (t == QUESTION)
+	{
+		str1 = ft_itoa(data->exit_status);
+		arg_param = str1;
+	}
+	if (!arg_param)
+		arg_param = "";
 	str2 = ft_strjoin(*args, arg_param);
+	free(str1);
 	str1 = ft_strjoin(str2, *parg);
 	if (str1 && str2)
 		*parg = str1 + ft_strlen(str2);
 	free(str2);
 	free(*args);
 	*args = str1;
+}
+
+static void	check_parameter(char **args, char **parg, t_data *data)
+{
+	int	type;
+
+	if ((*parg)[0] == TILDE && (!(*parg)[1] || is_whitespace((*parg)[1])))
+		type = TILDE;
+	else if ((*parg)[0] == DOLLAR && (*parg)[1] == QUESTION)
+		type = QUESTION;
+	else if ((*parg)[0] == DOLLAR
+		&& (ft_isalpha((*parg)[1]) || (*parg)[1] == UNDERSCORE))
+		type = DOLLAR;
+	else
+	{
+		(*parg)++;
+		return ;
+	}
+	*(*parg)++ = '\0';
+	parameter_expansion(args, parg, data, type);
 }
 
 static void	quote_removal(char **args, char **parg, const char q, t_data *data)
@@ -58,12 +80,7 @@ static void	quote_removal(char **args, char **parg, const char q, t_data *data)
 	str1 = ft_substr(*parg, 0, arg_close - *parg);
 	str2 = str1;
 	while (q == QUOTE_D && str1 && str2 && *str2)
-	{
-		if (is_parameter(str2))
-			parameter_expansion(&str1, &str2, data);
-		else
-			++str2;
-	}
+		check_parameter(&str1, &str2, data);
 	str2 = ft_strjoin(*args, str1);
 	free(str1);
 	str1 = ft_strjoin(str2, ++arg_close);
@@ -87,10 +104,8 @@ void	shell_expansion(t_data *data, char **args)
 		{
 			if (*arg == QUOTE_S || *arg == QUOTE_D)
 				quote_removal(args, &arg, *arg, data);
-			else if (is_parameter(arg))
-				parameter_expansion(args, &arg, data);
 			else
-				++arg;
+				check_parameter(args, &arg, data);
 		}
 		++args;
 	}

--- a/src/executor/shell_expansion.c
+++ b/src/executor/shell_expansion.c
@@ -6,52 +6,46 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 19:12:32 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/09/07 21:02:17 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 01:55:14 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-static void	parameter_expansion(char **args, char **parg, t_data *data, int t)
+static char	*parameter_expansion(char **args, char **parg, t_data *data, int t)
 {
-	char	*arg_param;
 	char	*str1;
 	char	*str2;
 
+	str1 = NULL;
 	if (t == TILDE)
-	{
-		str1 = NULL;
-		arg_param = getenv("HOME");
-	}
-	else
-		arg_param = (*parg)++;
-	if (t == DOLLAR)
-	{
-		while (ft_isalnum(**parg) || **parg == UNDERSCORE)
-			++*parg;
-		str1 = ft_substr(arg_param, 0, *parg - arg_param);
-		arg_param = getenv(str1);
-	}
+		str2 = getenv("HOME");
 	else if (t == QUESTION)
 	{
+		(*parg)++;
 		str1 = ft_itoa(data->exit_status);
-		arg_param = str1;
+		str2 = str1;
 	}
-	if (!arg_param)
-		arg_param = "";
-	str2 = ft_strjoin(*args, arg_param);
+	else
+	{
+		str2 = (*parg)++;
+		while (ft_isalnum(**parg) || **parg == UNDERSCORE)
+			++*parg;
+		str1 = ft_substr(str2, 0, *parg - str2);
+		str2 = getenv(str1);
+	}
+	if (!str2)
+		str2 = "";
+	str2 = ft_strjoin(*args, str2);
 	free(str1);
-	str1 = ft_strjoin(str2, *parg);
-	if (str1 && str2)
-		*parg = str1 + ft_strlen(str2);
-	free(str2);
-	free(*args);
-	*args = str1;
+	return (str2);
 }
 
 static void	check_parameter(char **args, char **parg, t_data *data)
 {
-	int	type;
+	int		type;
+	char	*str1;
+	char	*str2;
 
 	if ((*parg)[0] == TILDE && (!(*parg)[1] || is_whitespace((*parg)[1])))
 		type = TILDE;
@@ -66,7 +60,13 @@ static void	check_parameter(char **args, char **parg, t_data *data)
 		return ;
 	}
 	*(*parg)++ = '\0';
-	parameter_expansion(args, parg, data, type);
+	str2 = parameter_expansion(args, parg, data, type);
+	str1 = ft_strjoin(str2, *parg);
+	if (str1 && str2)
+		*parg = str1 + ft_strlen(str2);
+	free(str2);
+	free(*args);
+	*args = str1;
 }
 
 static void	quote_removal(char **args, char **parg, const char q, t_data *data)

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/31 13:35:36 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/08 15:27:07 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 18:35:46 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,8 +48,7 @@ int	error_message(char *source, char *err_str, int code)
 {
 	ft_putstr_fd(source, STDERR_FILENO);
 	ft_putstr_fd(": ", STDERR_FILENO);
-	ft_putstr_fd(err_str, STDERR_FILENO);
-	ft_putchar_fd('\n', STDERR_FILENO);
+	ft_putendl_fd(err_str, STDERR_FILENO);
 	return (code);
 }
 
@@ -62,7 +61,7 @@ void	exit_minishell(t_data *data, char *source, char *err_str, int code)
 		ft_putstr_fd("minishell: ", STDERR_FILENO);
 		exit(error_message(source, err_str, code));
 	}
-	exit(EXIT_SUCCESS);
+	exit(code);
 }
 
 void	start_minishell(void)

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/31 13:35:36 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/07 19:01:52 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/08 15:27:07 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,22 +44,24 @@ void	clear_data(t_data *data)
 	free(data->cmd_path);
 }
 
-void	exit_minishell(t_data *data, char *str, char *error_str, int code)
+int	error_message(char *source, char *err_str, int code)
 {
-	extern char	**environ;
+	ft_putstr_fd(source, STDERR_FILENO);
+	ft_putstr_fd(": ", STDERR_FILENO);
+	ft_putstr_fd(err_str, STDERR_FILENO);
+	ft_putchar_fd('\n', STDERR_FILENO);
+	return (code);
+}
 
-	if (str)
-	{
-		ft_putstr_fd("minishell: ", STDERR_FILENO);
-		ft_putstr_fd(str, STDERR_FILENO);
-		ft_putstr_fd(": ", STDERR_FILENO);
-		ft_putstr_fd(error_str, STDERR_FILENO);
-		ft_putchar_fd('\n', STDERR_FILENO);
-	}
+void	exit_minishell(t_data *data, char *source, char *err_str, int code)
+{
 	clear_data(data);
 	array_clear(&data->envp);
-	if (str)
-		exit(code);
+	if (source)
+	{
+		ft_putstr_fd("minishell: ", STDERR_FILENO);
+		exit(error_message(source, err_str, code));
+	}
 	exit(EXIT_SUCCESS);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/31 13:35:36 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/07 18:56:22 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/07 19:01:52 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,6 @@ void	exit_minishell(t_data *data, char *str, char *error_str, int code)
 	}
 	clear_data(data);
 	array_clear(&data->envp);
-	free(data->exit_status);
 	if (str)
 		exit(code);
 	exit(EXIT_SUCCESS);
@@ -70,7 +69,7 @@ void	start_minishell(void)
 
 	dt.envp = array_dup(environ);
 	environ = dt.envp;
-	dt.exit_status = ft_itoa(0);
+	dt.exit_status = 0;
 	dt.tokens = NULL;
 	dt.cmds = NULL;
 	dt.cmd_path = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/31 13:35:36 by wlin              #+#    #+#             */
-/*   Updated: 2024/09/04 13:50:07 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/09/07 18:56:22 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,7 +57,7 @@ void	exit_minishell(t_data *data, char *str, char *error_str, int code)
 		ft_putchar_fd('\n', STDERR_FILENO);
 	}
 	clear_data(data);
-	array_clear(&environ);
+	array_clear(&data->envp);
 	free(data->exit_status);
 	if (str)
 		exit(code);
@@ -68,6 +68,8 @@ void	start_minishell(void)
 {
 	t_data	dt;
 
+	dt.envp = array_dup(environ);
+	environ = dt.envp;
 	dt.exit_status = ft_itoa(0);
 	dt.tokens = NULL;
 	dt.cmds = NULL;
@@ -83,16 +85,11 @@ void	start_minishell(void)
 
 int	main(int argc, char **argv)
 {
-	extern char	**environ;
-
 	if (argc == 2 && ft_strncmp(argv[1], "test", 5) == 0)
 		test_lexer();
 	else if (argc == 2 && ft_strncmp(argv[1], "-v", 3) == 0)
 		return (printf("%s, version %s\n", NAME, VERSION), 0);
 	else
-	{
-		environ = array_dup(environ);
 		start_minishell();
-	}
 	return (0);
 }


### PR DESCRIPTION
This PR contains:
> Management of the exit status code, including expansion of the **?** variable
> Code for the **exit** *builtin*
> Finally corrected the mess with the "**environ** memory leak"
> As a bonus, I added the tilde (**~**) variable that stands for the **HOME** variable