### PR TITLE
Expanded the capabilities of the auxiliary array functions

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/20 14:55:24 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/20 15:37:12 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,6 +86,12 @@
 
 # define SIGINT_CODE 130
 # define SIGQUIT_CODE 131
+
+enum e_location
+{
+	BACK,
+	FRONT
+};
 
 typedef enum e_metachar
 {
@@ -211,12 +217,12 @@ int			is_builtin(t_bfunc *dst, char *cmd);
 
 /*===============================AUXILIARY FUNCTIONS==========================*/
 
-char		**array_add_front(char ***parray, char *str);
+char		**array_add(char ***parray, char *str, enum e_location l);
 void		array_clear(char ***parray);
 char		**array_dup(char **array);
 char		**array_join(char **array1, char **array2);
 size_t		array_len(char **array);
-char		**array_merge_back(char ***parray1, char **array2);
+char		**array_merge(char ***parray1, char **array2, enum e_location l);
 int			char_index(char *args, char ref);
 int			find_end_chars_index(char *input, int i);
 int			is_equal(char *s1, char *s2);

--- a/src/auxiliaries/aux_array.c
+++ b/src/auxiliaries/aux_array.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <rtorrent@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/28 21:08:04 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/02 15:28:10 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/20 15:40:20 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -57,40 +57,21 @@ char	**array_dup(char **array)
 	return (a0);
 }
 
-char	**array_add_front(char ***parray, char *str)
-{
-	char **const	a0 = malloc((array_len(*parray) + 2) * sizeof(char *));
-	char			**a;
-	char			**array;
-
-	if (a0)
-	{
-		a = a0;
-		*a++ = str;
-		array = *parray;
-		while (*array)
-			*a++ = *array++;
-		*a = NULL;
-		free(*parray);
-		*parray = a0;
-	}
-	return (a0);
-}
-
-char	**array_merge_back(char ***parray1, char **array2)
+char	**array_merge(char ***parray1, char **array2, enum e_location l)
 {
 	char **const	a0 = malloc((array_len(*parray1) + array_len(array2) + 1)
 			* sizeof(char *));
 	char			**a;
 	char			**array;
+	char **const	blocks[2] = {*parray1, array2};
 
 	if (a0)
 	{
 		a = a0;
-		array = *parray1;
+		array = blocks[0 ^ l];
 		while (*array)
 			*a++ = *array++;
-		array = array2;
+		array = blocks[1 ^ l];
 		while (*array)
 			*a++ = *array++;
 		*a = NULL;
@@ -98,4 +79,9 @@ char	**array_merge_back(char ***parray1, char **array2)
 		*parray1 = a0;
 	}
 	return (a0);
+}
+
+char	**array_add(char ***parray, char *str, enum e_location l)
+{
+	return (array_merge(parray, (char *[2]){str, NULL}, l));
 }

--- a/src/executor/process.c
+++ b/src/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/23 18:16:01 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/20 15:41:55 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/20 16:17:25 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ void	execute_command(t_data *data, char *command_path, char **cmd_args)
 	int		e;
 
 	execve(command_path, cmd_args, data->envp);
-	shell_path = getenv("SHELL");
+	shell_path = getenvp(data->envp, "SHELL");
 	if (shell_path)
 	{
 		e = errno;

--- a/src/executor/process.c
+++ b/src/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/23 18:16:01 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/19 15:04:33 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/20 15:41:55 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,7 @@ void	execute_command(t_data *data, char *command_path, char **cmd_args)
 	if (shell_path)
 	{
 		e = errno;
-		execve(shell_path, array_add_front(&cmd_args, shell_path), data->envp);
+		execve(shell_path, array_add(&cmd_args, shell_path, FRONT), data->envp);
 		exit_minishell(data, e, 3, SHNAME, cmd_args[1], strerror(e));
 	}
 	exit_minishell(data, errno, 3, SHNAME, cmd_args[0], strerror(errno));

--- a/src/executor/shell_expansion.c
+++ b/src/executor/shell_expansion.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 19:12:32 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/19 14:04:17 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/20 15:43:42 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ static void	word_split(char ***pargs, char ***pparg)
 	free(**pparg);
 	*(*pparg)++ = NULL;
 	n = array_len(*pargs) + array_len(split_arg);
-	array_merge_back(pargs, array_merge_back(&split_arg, *pparg));
+	array_merge(pargs, array_merge(&split_arg, *pparg, BACK), BACK);
 	free(split_arg);
 	*pparg = *pargs + n - 1;
 }


### PR DESCRIPTION
For the **export** *builtin*, I need  a new `array_add_back` function to append the new variable into the environment. Currently, we have `array_add_front` and `array_merge_back`. It occurred to me that it was silly to code a new `array_add_back` when all these functions essentially perform the same work. More importantly, *WE HAD REACHED THE FUNCTION LIMIT FROM  NORMINETTE*.

Word-splitting has been thoroughly tested. Nothing broken.