### PR TITLE
'export' builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/30 13:11:23 by wlin              #+#    #+#              #
-#    Updated: 2024/10/20 14:52:02 by rtorrent         ###   ########.fr        #
+#    Updated: 2024/10/21 18:30:17 by rtorrent         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -33,7 +33,7 @@ FILES_PARS		= parser.c parser_syntax.c parser_utils.c
 FILES_EXEC		= executor.c exec_find_cmd.c here_doc.c process_init.c\
 				  process.c exec_utils.c  split_path.c shell_expansion.c\
 				  get_value.c
-FILES_BLT		= builtin.c echo.c env.c exit.c pwd.c unset.c
+FILES_BLT		= builtin.c echo.c env.c exit.c export.c pwd.c unset.c
 FILES_AUX		= aux_array.c aux_str.c
 FILES_TEST		= test_lexer.c
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/21 17:27:25 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/22 01:43:50 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -165,6 +165,7 @@ int			error_message(int code, int n, ...);
 void		exit_minishell(t_data *data, int code, int n, ...);
 char		*getenvp(char **envp, char *name);
 void		set_signal(int mode);
+void		setenvp(char ***penvp, char *name, char *value);
 
 /*======================================LEXER=================================*/
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/20 15:37:12 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 17:27:25 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -136,7 +136,7 @@ typedef struct s_commands
 typedef struct s_data
 {
 	int			exit_status;
-	char		**envp;
+	char		**export_vars;
 	char		*line;
 	t_token		*tokens;
 	t_commands	*cmds;
@@ -160,6 +160,7 @@ typedef struct s_process
 /*===================================MINISHELL================================*/
 
 void		clear_data(t_data *data);
+char		**env_array(char **export_vars);
 int			error_message(int code, int n, ...);
 void		exit_minishell(t_data *data, int code, int n, ...);
 char		*getenvp(char **envp, char *name);

--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/21 14:12:00 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/13 20:12:47 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 12:58:31 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,10 @@
 
 int	is_builtin(t_bfunc *dst, char *cmd)
 {
-	static const char		*builtin[] = {"echo", "env", "exit", "pwd", "unset",
-		NULL};
-	static const t_bfunc	bt_func[] = {bt_echo, bt_env, bt_exit, bt_pwd,
-		bt_unset, NULL};
+	static const char		*builtin[] = {"echo", "env", "exit", "export",
+		"pwd", "unset", NULL};
+	static const t_bfunc	bt_func[] = {bt_echo, bt_env, bt_exit, bt_export,
+		bt_pwd, bt_unset, NULL};
 	const char				**b;
 
 	b = builtin;

--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/23 12:41:57 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/19 15:09:00 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 17:43:21 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,12 +18,18 @@ int	bt_env(int argc, char *argv[], t_data *data)
 {
 	char	**ep;
 
-	ep = data->envp;
+	ep = data->export_vars;
 	if (argc > 1)
 		return (error_message(ENV_ERROR, 3, "env", *++argv,
 				"invalid option/argument"));
 	if (ep)
+	{
 		while (*ep)
-			ft_putendl_fd(*ep++, STDOUT_FILENO);
+		{
+			if (ft_strchr(*ep, EQUALS))
+				ft_putendl_fd(*ep, STDOUT_FILENO);
+			ep++;
+		}
+	}
 	return (EXIT_SUCCESS);
 }

--- a/src/builtin/export.c
+++ b/src/builtin/export.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/21 12:55:50 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/21 19:08:11 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/22 01:41:38 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,15 +67,15 @@ int	bt_export(int argc, char *argv[], t_data *data)
 		if (ft_isalpha(*p) || *p == UNDERSCORE)
 			while (ft_isalnum(*++p) || *p == UNDERSCORE)
 				;
-		if (*p && *p != EQUALS)
+		if (!*p || *p == EQUALS)
+			setenvp(&data->export_vars, *argv++, p);
+		else
 		{
 			p = quote_str(*argv++);
 			argc = error_message(EXIT_FAILURE, 4, SHNAME, "export", p,
 					"not a valid identifier");
 			free(p);
 		}
-		else
-			array_add(&data->export_vars, ft_strdup(*argv++), BACK);
 	}
 	return (argc);
 }

--- a/src/builtin/export.c
+++ b/src/builtin/export.c
@@ -1,0 +1,81 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   export.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/10/21 12:55:50 by rtorrent          #+#    #+#             */
+/*   Updated: 2024/10/21 19:08:11 by rtorrent         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+#define EXPORT_ERROR 2
+
+static int	print_export_vars(char **vars)
+{
+	char	*equals;
+
+	while (*vars)
+	{
+		ft_putstr_fd("declare -x ", STDOUT_FILENO);
+		equals = ft_strchr(*vars, EQUALS);
+		if (equals)
+		{
+			dprintf(STDOUT_FILENO, "%.*s", (int)(equals - *vars), *vars);
+			ft_putstr_fd("=\"", STDOUT_FILENO);
+			if (*++equals)
+				ft_putstr_fd(equals, STDOUT_FILENO);
+			ft_putendl_fd("\"", STDOUT_FILENO);
+		}
+		else
+			ft_putendl_fd(*vars, STDOUT_FILENO);
+		vars++;
+	}
+	return (EXIT_SUCCESS);
+}
+
+static char	*quote_str(char *str)
+{
+	const size_t	n = ft_strlen(str) + 3;
+	char *const		p = malloc(n);
+
+	if (p)
+	{
+		ft_strlcpy(p, "`", 2);
+		ft_strlcat(p, str, n);
+		ft_strlcat(p, "\'", n);
+	}
+	return (p);
+}
+
+int	bt_export(int argc, char *argv[], t_data *data)
+{
+	char	*p;
+
+	argc = EXIT_SUCCESS;
+	if (*++argv && **argv == MINUS && (*argv)[1])
+		return (error_message(EXPORT_ERROR, 4, SHNAME, "export",
+				(char [3]){MINUS, (*argv)[1], '\0'}, "invalid option"));
+	if (!*argv)
+		return (print_export_vars(data->export_vars));
+	while (*argv)
+	{
+		p = *argv;
+		if (ft_isalpha(*p) || *p == UNDERSCORE)
+			while (ft_isalnum(*++p) || *p == UNDERSCORE)
+				;
+		if (*p && *p != EQUALS)
+		{
+			p = quote_str(*argv++);
+			argc = error_message(EXIT_FAILURE, 4, SHNAME, "export", p,
+					"not a valid identifier");
+			free(p);
+		}
+		else
+			array_add(&data->export_vars, ft_strdup(*argv++), BACK);
+	}
+	return (argc);
+}

--- a/src/builtin/unset.c
+++ b/src/builtin/unset.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/28 12:06:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/19 14:57:23 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 17:50:19 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,15 +30,15 @@ int	bt_unset(int argc, char *argv[], t_data *data)
 	char	**ep;
 	size_t	n;
 
-	if (!data->envp)
+	if (!data->export_vars)
 		return (EXIT_FAILURE);
 	while (--argc)
 	{
 		n = ft_strlen(*++argv);
-		ep = data->envp;
+		ep = data->export_vars;
 		while (*ep)
 		{
-			if (!ft_strncmp(*ep, *argv, n) && (*ep)[n] == EQUALS)
+			if (!ft_strncmp(*ep, *argv, n) && ((*ep)[n] == EQUALS || !(*ep)[n]))
 			{
 				remove_name(ep);
 				break ;

--- a/src/executor/exec_find_cmd.c
+++ b/src/executor/exec_find_cmd.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:12:56 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/20 14:59:45 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 17:11:55 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,7 +69,7 @@ char	*examine_path(char **path_dirs, char *cmd)
 
 char	*find_cmd_path(t_data *data, char *cmd)
 {
-	char *const	env = getenvp(data->envp, "PATH");
+	char *const	env = getenvp(data->export_vars, "PATH");
 	char		*full_path;
 	char		**path_dirs;
 

--- a/src/executor/process.c
+++ b/src/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/23 18:16:01 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/20 16:17:25 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 17:33:08 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,15 +14,16 @@
 
 void	execute_command(t_data *data, char *command_path, char **cmd_args)
 {
-	char	*shell_path;
-	int		e;
+	char			*shell_path;
+	char **const	envp = env_array(data->export_vars);
+	int				e;
 
-	execve(command_path, cmd_args, data->envp);
-	shell_path = getenvp(data->envp, "SHELL");
+	execve(command_path, cmd_args, envp);
+	shell_path = getenvp(envp, "SHELL");
 	if (shell_path)
 	{
 		e = errno;
-		execve(shell_path, array_add(&cmd_args, shell_path, FRONT), data->envp);
+		execve(shell_path, array_add(&cmd_args, shell_path, FRONT), envp);
 		exit_minishell(data, e, 3, SHNAME, cmd_args[1], strerror(e));
 	}
 	exit_minishell(data, errno, 3, SHNAME, cmd_args[0], strerror(errno));

--- a/src/executor/shell_expansion.c
+++ b/src/executor/shell_expansion.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/03 19:12:32 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/20 15:43:42 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 17:35:35 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,7 +43,7 @@ static char	*parameter_expansion(t_data *data, char **args, char **parg,
 		while (ft_isalnum(**parg) || **parg == UNDERSCORE)
 			++*parg;
 		str1 = ft_substr(str1, 0, *parg - str1);
-		get_value(data->envp, &str1, flags);
+		get_value(data->export_vars, &str1, flags);
 	}
 	if (str1)
 		str2 = ft_strjoin(*args, str1);

--- a/src/main/environment.c
+++ b/src/main/environment.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/20 14:50:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/20 14:54:08 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 17:30:18 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,4 +27,19 @@ char	*getenvp(char **envp, char *name)
 		}
 	}
 	return (NULL);
+}
+
+char	**env_array(char **export_vars)
+{
+	char	**p;
+
+	p = array_dup((char *[1]){NULL});
+	while (p && *export_vars)
+	{
+		if (ft_strchr(*export_vars, EQUALS)
+			&& !array_add(&p, *export_vars, BACK))
+			array_clear(&p);
+		export_vars++;
+	}
+	return (p);
 }

--- a/src/main/environment.c
+++ b/src/main/environment.c
@@ -6,11 +6,34 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/20 14:50:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/21 17:30:18 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/22 03:19:34 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+void	setenvp(char ***penvp, char *var, char *equals)
+{
+	char			**p;
+	const size_t	n = equals - var;
+
+	p = *penvp;
+	if (!p)
+		return ;
+	while (*p)
+	{
+		if (!ft_strncmp(*p, var, n) && (!(*p)[n] || (*p)[n] == EQUALS))
+			break ;
+		p++;
+	}
+	if (*p)
+	{
+		free(*p);
+		*p = ft_strdup(var);
+	}
+	else
+		array_add(penvp, ft_strdup(var), BACK);
+}
 
 char	*getenvp(char **envp, char *name)
 {
@@ -21,7 +44,8 @@ char	*getenvp(char **envp, char *name)
 		n = ft_strlen(name);
 		while (*envp)
 		{
-			if (!ft_strncmp(*envp, name, n) && (*envp)[n] == EQUALS)
+			if (!ft_strncmp(*envp, name, n)
+				&& (!(*envp)[n] || (*envp)[n] == EQUALS))
 				return (*envp + ++n);
 			envp++;
 		}

--- a/src/main/exit_minishell.c
+++ b/src/main/exit_minishell.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/07 17:38:36 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/07 20:51:36 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 17:10:33 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,6 +43,6 @@ void	exit_minishell(t_data *data, int code, int n, ...)
 		verror_message(n, &ap);
 	va_end(ap);
 	clear_data(data);
-	array_clear(&data->envp);
+	array_clear(&data->export_vars);
 	exit(code);
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/31 13:35:36 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/19 15:14:58 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/21 19:00:09 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,13 +64,13 @@ static void	start_minishell(void)
 {
 	t_data	dt;
 
-	reset_data(&dt);
-	dt.envp = array_dup(environ);
-// TODO **** Increse SHLVL variable by one
+	dt.export_vars = array_dup(environ);
+// TODO **** Increse SHLVL variable by one + export PWD
 	dt.exit_status = 0;
 	set_signal(PARENT);
 	while (TRUE)
 	{
+		reset_data(&dt);
 		g_sigstatus = 0;
 		dt.line = readline(PROMPT);
 		if (g_sigstatus != 0)
@@ -86,7 +86,6 @@ static void	start_minishell(void)
 		if (dt.line == NULL)
 			bt_exit(1, NULL, &dt);
 		clear_data(&dt);
-		reset_data(&dt);
 	}
 }
 


### PR DESCRIPTION
Monumental changes everywhere.

The major difference is that the string array in `data`, previously `data->envp`, now stores the "exportable" array of variables. The `env` *builtin* and the children processes now require a sort of duplication, with the incomplete variables filtered out. By "incomplete" I mean variables such as `$BLABLA` in `export BLABLA`, that now exists in the array but has no assigned value.

I've tried several instructions with the new array, and the **shell expansion** does not crash. It also works with the "incomplete" lot.

I have not detected memory *leaks* with `-fsanitize` on, but who knows… 