### PR TITLE
cd builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2024/05/30 13:11:23 by wlin              #+#    #+#              #
-#    Updated: 2024/10/22 19:08:51 by rtorrent         ###   ########.fr        #
+#    Updated: 2024/10/26 17:24:47 by rtorrent         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -33,7 +33,7 @@ FILES_PARS		= parser.c parser_syntax.c parser_utils.c
 FILES_EXEC		= executor.c exec_find_cmd.c here_doc.c process_init.c\
 				  process.c exec_utils.c  split_path.c shell_expansion.c\
 				  get_value.c heredoc_utils.c
-FILES_BLT		= builtin.c echo.c env.c exit.c export.c pwd.c unset.c
+FILES_BLT		= builtin.c echo.c env.c exit.c export.c cd.c pwd.c unset.c
 FILES_AUX		= aux_array.c aux_str.c
 FILES_TEST		= test_lexer.c
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/26 16:45:19 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 18:34:58 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,6 +52,7 @@
 # define DOLLAR 36
 # define QUOTE_S 39
 # define MINUS 45
+# define SLASH 47
 # define C_LESS 60
 # define EQUALS 61
 # define C_GREAT 62
@@ -140,6 +141,7 @@ typedef struct s_commands
 typedef struct s_data
 {
 	int			exit_status;
+	char		**env;
 	char		**export_vars;
 	char		*line;
 	t_token		*tokens;
@@ -171,11 +173,12 @@ typedef struct s_heredoc
 /*===================================MINISHELL================================*/
 
 void		clear_data(t_data *data);
-char		**env_array(char **export_vars);
 int			error_message(int code, int n, ...);
 void		exit_minishell(t_data *data, int code, int n, ...);
 void		export_var(char ***pexport_vars, char *var, char *equals);
-char		*getenvp(char **envp, char *name);
+char		**filter_env_array(char **export_vars);
+char		*ft_getenv(char **env, char *name);
+int			ft_setenv(char ***penv, char *name, char *value);
 void		set_signal(enum e_mode mode);
 
 /*======================================LEXER=================================*/
@@ -206,8 +209,8 @@ void		cmd_lst_addback(t_commands **cmds, t_commands *new);
 pid_t		create_process(t_data *data, t_process *process);
 int			execute_all(t_data *data, t_commands *cmds);
 void		fd_dup2(t_data *data, int oldfd, int newfd);
-char		*find_cmd_path(t_data *data, char *cmd);
-void		get_value(char **envp, char **pstr, unsigned int flags);
+char		*find_cmd_path(char **env, char *path_name, char *cmd);
+void		get_value(char **env, char **pstr, unsigned int flags);
 char		*heredoc_create_filename(void);
 int			heredoc_fork(t_data *data, char **pwrd);
 int			heredoc_iter(t_data *data, t_commands *cmd,

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:16:12 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/28 18:34:58 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/29 11:57:42 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -177,8 +177,8 @@ int			error_message(int code, int n, ...);
 void		exit_minishell(t_data *data, int code, int n, ...);
 void		export_var(char ***pexport_vars, char *var, char *equals);
 char		**filter_env_array(char **export_vars);
-char		*ft_getenv(char **env, char *name);
-int			ft_setenv(char ***penv, char *name, char *value);
+char		*get_from_env(char **env, char *name);
+int			set_in_env(char ***pexport_vars, char *name, char *value);
 void		set_signal(enum e_mode mode);
 
 /*======================================LEXER=================================*/

--- a/src/auxiliaries/aux_array.c
+++ b/src/auxiliaries/aux_array.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <rtorrent@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/28 21:08:04 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/20 15:40:20 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/29 14:29:05 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,15 +63,15 @@ char	**array_merge(char ***parray1, char **array2, enum e_location l)
 			* sizeof(char *));
 	char			**a;
 	char			**array;
-	char **const	blocks[2] = {*parray1, array2};
+	char **const	src[2] = {*parray1, array2};
 
 	if (a0)
 	{
 		a = a0;
-		array = blocks[0 ^ l];
+		array = src[0 ^ l];
 		while (*array)
 			*a++ = *array++;
-		array = blocks[1 ^ l];
+		array = src[1 ^ l];
 		while (*array)
 			*a++ = *array++;
 		*a = NULL;
@@ -83,5 +83,7 @@ char	**array_merge(char ***parray1, char **array2, enum e_location l)
 
 char	**array_add(char ***parray, char *str, enum e_location l)
 {
+	if (!*str)
+		return (NULL);
 	return (array_merge(parray, (char *[2]){str, NULL}, l));
 }

--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/21 14:12:00 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/21 12:58:31 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/26 17:26:07 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,9 +15,9 @@
 int	is_builtin(t_bfunc *dst, char *cmd)
 {
 	static const char		*builtin[] = {"echo", "env", "exit", "export",
-		"pwd", "unset", NULL};
+		"cd", "pwd", "unset", NULL};
 	static const t_bfunc	bt_func[] = {bt_echo, bt_env, bt_exit, bt_export,
-		bt_pwd, bt_unset, NULL};
+		bt_cd, bt_pwd, bt_unset, NULL};
 	const char				**b;
 
 	b = builtin;

--- a/src/builtin/cd.c
+++ b/src/builtin/cd.c
@@ -6,31 +6,58 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/26 17:26:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/26 18:40:02 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/27 21:15:30 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+char	*test_cdpath(char **pcurpath, char *directory)
+{
+//TODO: split de CDPATH
+	*pcurpath = ft_strdup(*pcurpath);
+	return (*pcurpath);
+}
+
 static int	previous_directory(t_data *data)
 {
 	char *const	oldpwd = getenvp(data->export_vars, "OLDPWD");
-	int			ret1;
-	int			ret2;
+	int			ret;
 
 	if (!oldpwd)
 		return (error_message(EXIT_FAILURE, 3, SHNAME, "cd", "OLDPWD not set"));
-	ret1 = bt_cd(2, (char *[3]){"cd", oldpwd, NULL}, data);
-	ret2 = bt_pwd(1, (char *[2]){"pwd", NULL}, data);
-	
-// TODO: return value of `cd "$OLDPWD" && pwd'
+	ret = bt_cd(2, (char *[3]){"cd", oldpwd, NULL}, data);
+	if (ret)
+		return (ret);
+	return (bt_pwd(1, (char *[2]){"pwd", NULL}, data));
+}
+
+static int	home_directory(t_data *data)
+{
+	char *const	home = getenvp(data->export_vars, "HOME");
+
+	if (!home)
+		return (error_message(EXIT_FAILURE, 3, SHNAME, "cd", "HOME not set"));
+	return (bt_cd(2, (char *[3]){"cd", home, NULL}, data));
 }
 
 int	bt_cd(int argc, char *argv[], t_data *data)
 {
-	if (argc == 2 && ft_strncmp(*argv[1], "-", -1))
+	char	**directory;
+	char	*curpath;
+
+	if (argc == 1)
+		return (home_directory(data));
+	else if (argc == 2 && ft_strncmp(*argv[1], "-", -1))
 		return (previous_directory(data));
-
-
+	if (argc > 2 || !test_cdpath(&curpath, argv[1]));
+		return (error_message(EXIT_FAILURE, 3, SHNAME, "cd",
+				"too many arguments"));
+	curpath = test_cdpath(argv[1]);
+	directory = ft_split(argv[1], SLASH);
+	if (!directory)
+		exit_minishell(data, errno, 3, SHNAME, "cd", strerror(errno));
+	free(curpath);
+	array_clear(&directory);
 	return (0);
 }

--- a/src/builtin/cd.c
+++ b/src/builtin/cd.c
@@ -1,0 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cd.c                                               :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/10/26 17:26:59 by rtorrent          #+#    #+#             */
+/*   Updated: 2024/10/26 18:40:02 by rtorrent         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	previous_directory(t_data *data)
+{
+	char *const	oldpwd = getenvp(data->export_vars, "OLDPWD");
+	int			ret1;
+	int			ret2;
+
+	if (!oldpwd)
+		return (error_message(EXIT_FAILURE, 3, SHNAME, "cd", "OLDPWD not set"));
+	ret1 = bt_cd(2, (char *[3]){"cd", oldpwd, NULL}, data);
+	ret2 = bt_pwd(1, (char *[2]){"pwd", NULL}, data);
+	
+// TODO: return value of `cd "$OLDPWD" && pwd'
+}
+
+int	bt_cd(int argc, char *argv[], t_data *data)
+{
+	if (argc == 2 && ft_strncmp(*argv[1], "-", -1))
+		return (previous_directory(data));
+
+
+	return (0);
+}

--- a/src/builtin/cd.c
+++ b/src/builtin/cd.c
@@ -6,22 +6,24 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/26 17:26:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/27 21:15:30 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 19:30:56 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
-char	*test_cdpath(char **pcurpath, char *directory)
+static int	test_first(char *directory, char *sequence)
 {
-//TODO: split de CDPATH
-	*pcurpath = ft_strdup(*pcurpath);
-	return (*pcurpath);
+	char *const	delim = ft_strchr(directory, SLASH);
+
+	if (!delim)
+		return (!ft_strncmp(directory, sequence, -1));
+	return (!ft_strncmp(directory, sequence, delim - directory));
 }
 
 static int	previous_directory(t_data *data)
 {
-	char *const	oldpwd = getenvp(data->export_vars, "OLDPWD");
+	char *const	oldpwd = ft_getenv(data->export_vars, "OLDPWD");
 	int			ret;
 
 	if (!oldpwd)
@@ -34,7 +36,7 @@ static int	previous_directory(t_data *data)
 
 static int	home_directory(t_data *data)
 {
-	char *const	home = getenvp(data->export_vars, "HOME");
+	char *const	home = ft_getenv(data->export_vars, "HOME");
 
 	if (!home)
 		return (error_message(EXIT_FAILURE, 3, SHNAME, "cd", "HOME not set"));
@@ -43,21 +45,34 @@ static int	home_directory(t_data *data)
 
 int	bt_cd(int argc, char *argv[], t_data *data)
 {
-	char	**directory;
 	char	*curpath;
 
 	if (argc == 1)
 		return (home_directory(data));
 	else if (argc == 2 && ft_strncmp(*argv[1], "-", -1))
 		return (previous_directory(data));
-	if (argc > 2 || !test_cdpath(&curpath, argv[1]));
+	else if (argc > 2);
 		return (error_message(EXIT_FAILURE, 3, SHNAME, "cd",
 				"too many arguments"));
-	curpath = test_cdpath(argv[1]);
-	directory = ft_split(argv[1], SLASH);
-	if (!directory)
-		exit_minishell(data, errno, 3, SHNAME, "cd", strerror(errno));
+	if (**++argv == SLASH || test_first(*argv, ".") || test_first(*argv, "..")) 
+		curpath = ft_strdup(*argv);
+	else
+	{
+		curpath = find_cmd_path(data->env, "CDPATH", *argv);
+		if (!cur_path)
+			curpath = ft_strjoin("./", *argv);
+	}
+	if (!curpath)
+		exit_minishell
+//TODO: ***		
+
+	if (curpath && access(curpath, F_OK) == INVALID)
+		return (error_message(EXIT_FAILURE, 4, SHNAME, "cd", *argv,
+				"No such file or directory");
+	if (curpath && access(curpath, X_OK) == INVALID)
+		return (error_message(EXIT_FAILURE, 4, SHNAME, "cd", *argv,
+				"Permission denied");
+
 	free(curpath);
-	array_clear(&directory);
 	return (0);
 }

--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/23 12:41:57 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/21 17:43:21 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 18:16:35 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,18 +18,12 @@ int	bt_env(int argc, char *argv[], t_data *data)
 {
 	char	**ep;
 
-	ep = data->export_vars;
+	ep = data->env;
 	if (argc > 1)
 		return (error_message(ENV_ERROR, 3, "env", *++argv,
 				"invalid option/argument"));
 	if (ep)
-	{
 		while (*ep)
-		{
-			if (ft_strchr(*ep, EQUALS))
-				ft_putendl_fd(*ep, STDOUT_FILENO);
-			ep++;
-		}
-	}
+			ft_putendl_fd(*ep++, STDOUT_FILENO);
 	return (EXIT_SUCCESS);
 }

--- a/src/builtin/pwd.c
+++ b/src/builtin/pwd.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/27 14:06:28 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/19 14:59:13 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/29 13:23:55 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,6 +23,8 @@ int	bt_pwd(int argc, char *argv[], t_data *data)
 		return (error_message(PWD_ERROR, 3, "pwd", *++argv, "invalid option"));
 	if (getcwd(pwd, PATH_MAX))
 		ft_putstr_fd(pwd, STDOUT_FILENO);
+	else
+		return (error_message(errno, 2, "pwd", strerror(errno)));
 	ft_putchar_fd('\n', STDOUT_FILENO);
 	return (EXIT_SUCCESS);
 }

--- a/src/executor/exec_find_cmd.c
+++ b/src/executor/exec_find_cmd.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:12:56 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/28 18:36:02 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/29 11:54:05 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,7 +69,7 @@ char	*examine_path(char **path_dirs, char *cmd)
 
 char	*find_cmd_path(char **env, char *path_name, char *cmd)
 {
-	char *const	path_value = ft_getenv(env, path_name);
+	char *const	path_value = get_from_env(env, path_name);
 	char		*full_path;
 	char		**path_dirs;
 

--- a/src/executor/exec_find_cmd.c
+++ b/src/executor/exec_find_cmd.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 13:12:56 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/21 17:11:55 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 18:36:02 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,21 +67,16 @@ char	*examine_path(char **path_dirs, char *cmd)
 	return (NULL);
 }
 
-char	*find_cmd_path(t_data *data, char *cmd)
+char	*find_cmd_path(char **env, char *path_name, char *cmd)
 {
-	char *const	env = getenvp(data->export_vars, "PATH");
+	char *const	path_value = ft_getenv(env, path_name);
 	char		*full_path;
 	char		**path_dirs;
 
-	if (!env)
+	if (!path_value)
 		return (ft_strdup(cmd));
-	if (char_index(cmd, '/') != NOT_FOUND)
-		return (ft_strdup(cmd));
-	path_dirs = split_path(env, ':');
+	path_dirs = split_path(path_value, ':');
 	full_path = examine_path(path_dirs, cmd);
-	data->cmd_path = full_path;
 	array_clear(&path_dirs);
-	if (full_path == NULL)
-		exit_minishell(data, NOTFOUND, 2, cmd, "command not found");
 	return (full_path);
 }

--- a/src/executor/executor.c
+++ b/src/executor/executor.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/22 11:46:39 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/26 16:23:56 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 18:32:48 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -89,8 +89,9 @@ int	execute_all(t_data *data, t_commands *cmds)
 		return (data->exit_status);
 	num_cmd = lst_size(cmds);
 	data->pid = malloc(sizeof(pid_t) * num_cmd);
-	if (data->pid == NULL)
-		exit_minishell(data, errno, 3, SHNAME, "malloc", strerror(errno));
+	data->env = filter_env_array(data->export_vars);
+	if (data->pid == NULL || data->env == NULL)
+		exit_minishell(data, errno, 2, SHNAME, strerror(errno));
 	shell_expansion(data, &cmds->args, QRM | EXP | WSP);
 	if (!is_builtin(NULL, cmds->args[0]) || num_cmd > 1)
 	{
@@ -98,8 +99,7 @@ int	execute_all(t_data *data, t_commands *cmds)
 		if (pipe_read_end_prev == INVALID)
 			exit_minishell(data, errno, 3, SHNAME, "dup", strerror(errno));
 		link_command(data, cmds, data->pid, pipe_read_end_prev);
-		num_cmd = wait_process(data->pid, num_cmd);
-		return (num_cmd);
+		return (wait_process(data->pid, num_cmd));
 	}
 	else
 		return (simple_command(data, cmds));

--- a/src/executor/get_value.c
+++ b/src/executor/get_value.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 20:17:10 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/28 18:36:44 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/29 11:53:33 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,7 @@ void	get_value(char **env, char **pstr, unsigned int flags)
 {
 	char	*value;
 
-	value = ft_getenv(env, *pstr);
+	value = get_from_env(env, *pstr);
 	if (value)
 	{
 		if (flags & INQ || !(flags & WSP))

--- a/src/executor/get_value.c
+++ b/src/executor/get_value.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/09/30 20:17:10 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/20 14:53:21 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 18:36:44 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,11 +20,11 @@ static char	mark_spaces(unsigned int i, char c)
 	return (UNIT_SEPARATOR);
 }
 
-void	get_value(char **envp, char **pstr, unsigned int flags)
+void	get_value(char **env, char **pstr, unsigned int flags)
 {
 	char	*value;
 
-	value = getenvp(envp, *pstr);
+	value = ft_getenv(env, *pstr);
 	if (value)
 	{
 		if (flags & INQ || !(flags & WSP))

--- a/src/executor/process.c
+++ b/src/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/23 18:16:01 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/28 18:37:32 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/29 12:19:00 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ void	execute_command(t_data *data, char *command_path, char **cmd_args)
 	int		e;
 
 	execve(command_path, cmd_args, data->env);
-	shell_path = ft_getenv(data->env, "SHELL");
+	shell_path = get_from_env(data->env, "SHELL");
 	if (shell_path)
 	{
 		e = errno;

--- a/src/executor/process.c
+++ b/src/executor/process.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/06/23 18:16:01 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/25 14:06:41 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 18:37:32 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,16 +14,15 @@
 
 void	execute_command(t_data *data, char *command_path, char **cmd_args)
 {
-	char			*shell_path;
-	char **const	envp = env_array(data->export_vars);
-	int				e;
+	char	*shell_path;
+	int		e;
 
-	execve(command_path, cmd_args, envp);
-	shell_path = getenvp(envp, "SHELL");
+	execve(command_path, cmd_args, data->env);
+	shell_path = ft_getenv(data->env, "SHELL");
 	if (shell_path)
 	{
 		e = errno;
-		execve(shell_path, array_add(&cmd_args, shell_path, FRONT), envp);
+		execve(shell_path, array_add(&cmd_args, shell_path, FRONT), data->env);
 		exit_minishell(data, e, 3, SHNAME, cmd_args[1], strerror(e));
 	}
 	exit_minishell(data, errno, 3, SHNAME, cmd_args[0], strerror(errno));

--- a/src/executor/process_init.c
+++ b/src/executor/process_init.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/27 18:46:09 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/09 15:34:00 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 18:17:46 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,11 +73,22 @@ static void	handle_redirection(t_data *data, t_process *process,
 void	init_process(t_data *data, t_process *process)
 {
 	t_redirect	*redirect;
+	char *const	cmd = process->comand->args[0];
 
-	if (process->command->args != NULL
-		&& !is_builtin(&process->builtin, process->command->args[0]))
+	if (process->command->args != NULL && !is_builtin(&process->builtin, cmd))
 	{
-		process->cmd_path = find_cmd_path(data, process->command->args[0]);
+		if (char_index(cmd, SLASH) != NOT_FOUND)
+		{
+			process->cmd_path = ft_strdup(cmd);
+			if (process->cmd_path == NULL)
+				exit_minishell(data, errno, 2, SHNAME, strerror(errno));
+		}
+		else
+		{
+			process->cmd_path = find_cmd_path(data->env, "PATH", cmd);
+			if (process->cmd_path == NULL)
+				exit_minishell(data, NOTFOUND, 2, cmd, "command not found");
+		}
 		data->cmd_path = process->cmd_path;
 	}
 	redirect = process->command->redirect;

--- a/src/executor/process_init.c
+++ b/src/executor/process_init.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/07/27 18:46:09 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/28 18:17:46 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/29 12:18:23 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -73,7 +73,7 @@ static void	handle_redirection(t_data *data, t_process *process,
 void	init_process(t_data *data, t_process *process)
 {
 	t_redirect	*redirect;
-	char *const	cmd = process->comand->args[0];
+	char *const	cmd = process->command->args[0];
 
 	if (process->command->args != NULL && !is_builtin(&process->builtin, cmd))
 	{

--- a/src/main/environment.c
+++ b/src/main/environment.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/20 14:50:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/22 18:58:16 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/26 18:38:56 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,6 +33,24 @@ void	export_var(char ***pexport_vars, char *var, char *equals)
 	}
 	else
 		array_add(pexport_vars, ft_strdup(var), BACK);
+}
+
+int	setenvp(char ***envp, char *name, char *value)
+{
+	value = ft_strjoin("=", value);
+	if (value)
+	{
+		name = ft_strjoin(name, value);
+		free(value);
+		if (name)
+		{
+			export_vars(envp, name, ft_strchr(name, EQUALS));
+			free(name);
+			return (EXIT_SUCCESS);
+		}
+		free(name);
+	}
+	return (EXIT_FAILURE);
 }
 
 char	*getenvp(char **envp, char *name)

--- a/src/main/environment.c
+++ b/src/main/environment.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/20 14:50:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/26 18:38:56 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 18:32:15 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ void	export_var(char ***pexport_vars, char *var, char *equals)
 		array_add(pexport_vars, ft_strdup(var), BACK);
 }
 
-int	setenvp(char ***envp, char *name, char *value)
+int	ft_setenv(char ***penv, char *name, char *value)
 {
 	value = ft_strjoin("=", value);
 	if (value)
@@ -44,7 +44,7 @@ int	setenvp(char ***envp, char *name, char *value)
 		free(value);
 		if (name)
 		{
-			export_vars(envp, name, ft_strchr(name, EQUALS));
+			export_vars(penv, name, ft_strchr(name, EQUALS));
 			free(name);
 			return (EXIT_SUCCESS);
 		}
@@ -53,25 +53,25 @@ int	setenvp(char ***envp, char *name, char *value)
 	return (EXIT_FAILURE);
 }
 
-char	*getenvp(char **envp, char *name)
+char	*ft_getenv(char **env, char *name)
 {
 	size_t	n;
 
 	if (name)
 	{
 		n = ft_strlen(name);
-		while (*envp)
+		while (*env)
 		{
-			if (!ft_strncmp(*envp, name, n)
-				&& (!(*envp)[n] || (*envp)[n] == EQUALS))
-				return (*envp + ++n);
-			envp++;
+			if (!ft_strncmp(*env, name, n)
+				&& (!(*env)[n] || (*env)[n] == EQUALS))
+				return (*env + ++n);
+			env++;
 		}
 	}
 	return (NULL);
 }
 
-char	**env_array(char **export_vars)
+char	**filter_env_array(char **export_vars)
 {
 	char	**p;
 

--- a/src/main/environment.c
+++ b/src/main/environment.c
@@ -6,7 +6,7 @@
 /*   By: rtorrent <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/10/20 14:50:59 by rtorrent          #+#    #+#             */
-/*   Updated: 2024/10/28 18:32:15 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/29 14:29:19 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,7 +35,7 @@ void	export_var(char ***pexport_vars, char *var, char *equals)
 		array_add(pexport_vars, ft_strdup(var), BACK);
 }
 
-int	ft_setenv(char ***penv, char *name, char *value)
+int	set_in_env(char ***pexport_vars, char *name, char *value)
 {
 	value = ft_strjoin("=", value);
 	if (value)
@@ -44,7 +44,7 @@ int	ft_setenv(char ***penv, char *name, char *value)
 		free(value);
 		if (name)
 		{
-			export_vars(penv, name, ft_strchr(name, EQUALS));
+			export_var(pexport_vars, name, ft_strchr(name, EQUALS));
 			free(name);
 			return (EXIT_SUCCESS);
 		}
@@ -53,7 +53,7 @@ int	ft_setenv(char ***penv, char *name, char *value)
 	return (EXIT_FAILURE);
 }
 
-char	*ft_getenv(char **env, char *name)
+char	*get_from_env(char **env, char *name)
 {
 	size_t	n;
 
@@ -73,15 +73,15 @@ char	*ft_getenv(char **env, char *name)
 
 char	**filter_env_array(char **export_vars)
 {
-	char	**p;
+	char	**env;
 
-	p = array_dup((char *[1]){NULL});
-	while (p && *export_vars)
+	env = array_dup((char *[1]){NULL});
+	while (env && *export_vars)
 	{
 		if (ft_strchr(*export_vars, EQUALS)
-			&& !array_add(&p, *export_vars, BACK))
-			array_clear(&p);
+			&& !array_add(&env, ft_strdup(*export_vars), BACK))
+			array_clear(&env);
 		export_vars++;
 	}
-	return (p);
+	return (env);
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/31 13:35:36 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/28 17:52:10 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/29 13:57:07 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,6 +69,7 @@ static void	start_minishell(void)
 	int		hd_exit;
 
 	dt.export_vars = array_dup(environ);
+	dt.env = NULL;
 // TODO **** Increse SHLVL variable by one + export PWD
 	dt.exit_status = 0;
 	while (TRUE)
@@ -91,7 +92,7 @@ static void	start_minishell(void)
 				ft_putchar_fd('\n', STDOUT_FILENO);
 		}
 		if (dt.line == NULL)
-			bt_exit(1, NULL, &dt);
+			bt_exit(1, (char *[2]){"exit", NULL}, &dt);
 		clear_data(&dt);
 	}
 }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -6,7 +6,7 @@
 /*   By: wlin <wlin@student.42.fr>                  +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/05/31 13:35:36 by wlin              #+#    #+#             */
-/*   Updated: 2024/10/26 16:24:27 by rtorrent         ###   ########.fr       */
+/*   Updated: 2024/10/28 17:52:10 by rtorrent         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,6 +46,7 @@ void	clear_data(t_data *data)
 	free(data->line);
 	free(data->pid);
 	free(data->cmd_path);
+	array_clear(&data->env);
 	heredoc_iter(data, data->cmds, heredoc_unlink);
 	clear_lists(data);
 }


### PR DESCRIPTION
This commit is unnecessarily long because:

- It makes use of the `find_cmd_path` in **exec_find_cmd.c**.
- It became obvious that a parallel "clean" environment array was necessary, beyond the `export_vars`.
- I changed the names of the environment variables. (again)

resolves #101 crash